### PR TITLE
Add expression to make operations =, <>, >, >=, <, <= in SQL storage

### DIFF
--- a/examples/dm_mysql_storage.py
+++ b/examples/dm_mysql_storage.py
@@ -23,6 +23,7 @@ from restalchemy.dm import properties
 from restalchemy.dm import relationships
 from restalchemy.dm import types
 from restalchemy.storage.sql import engines
+from restalchemy.storage.sql import filters
 from restalchemy.storage.sql import orm
 
 
@@ -56,7 +57,7 @@ class BarModel(models.ModelWithUUID, orm.SQLStorableMixin):
 
 
 engines.engine_factory.configure_factory(
-    db_url="mysql://test:OyO83AdIn9hbK3uz@cameron.synapse.net.ru/test")
+    db_url="mysql://test:test@127.0.0.1/test")
 
 
 # Create new foo object and store it
@@ -88,3 +89,15 @@ foo2.save()
 # Delete foo object from storage
 for foo in foos:
     foo.delete()
+
+
+six.print_("foo_field1 is greater than 5")
+for num in range(10):
+    foo = FooModel(foo_field1=num)
+    foo.save()
+
+six.print_(list(FooModel.objects.get_all(filters={
+    'foo_field1': filters.GT(5)})))
+
+for model in FooModel.objects.get_all():
+    model.delete()

--- a/restalchemy/storage/sql/filters.py
+++ b/restalchemy/storage/sql/filters.py
@@ -1,0 +1,73 @@
+# vim: tabstop=4 shiftwidth=4 softtabstop=4
+#
+# Copyright 2018 Eugene Frolov <eugene@frolov.net.ru>
+#
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import abc
+
+import six
+
+
+@six.add_metaclass(abc.ABCMeta)
+class AbstractExpression(object):
+
+    def __init__(self, value):
+        super(AbstractExpression, self).__init__()
+        self._value = value
+
+    @property
+    def value(self):
+        return self._value
+
+    @abc.abstractmethod
+    def construct_expression(self, name):
+        raise NotImplementedError()
+
+
+class EQ(AbstractExpression):
+
+    def construct_expression(self, name):
+        return ("`%s` = " % name) + "%s"
+
+
+class NE(AbstractExpression):
+
+    def construct_expression(self, name):
+        return ("`%s` <> " % name) + "%s"
+
+
+class GT(AbstractExpression):
+
+    def construct_expression(self, name):
+        return ("`%s` > " % name) + "%s"
+
+
+class GE(AbstractExpression):
+
+    def construct_expression(self, name):
+        return ("`%s` >= " % name) + "%s"
+
+
+class LT(AbstractExpression):
+
+    def construct_expression(self, name):
+        return ("`%s` < " % name) + "%s"
+
+
+class LE(AbstractExpression):
+
+    def construct_expression(self, name):
+        return ("`%s` <= " % name) + "%s"

--- a/restalchemy/tests/unit/storage/sql/dialect/test_mysql.py
+++ b/restalchemy/tests/unit/storage/sql/dialect/test_mysql.py
@@ -17,6 +17,7 @@
 #    under the License.
 
 from restalchemy.storage.sql.dialect import mysql
+from restalchemy.storage.sql import filters
 from restalchemy.tests.unit import base
 
 
@@ -87,13 +88,94 @@ class MySQLDeleteTestCase(base.BaseTestCase):
 class MySQLSelectTestCase(base.BaseTestCase):
 
     def setUp(self):
-        TABLE = FakeTable()
-        self.target = mysql.MySQLSelect(TABLE, dict(zip(
-            TABLE.get_column_names(), FAKE_VALUES)))
+        self._TABLE = FakeTable()
 
     def test_statement(self):
+        target = mysql.MySQLSelect(self._TABLE, dict(zip(
+            self._TABLE.get_column_names(), FAKE_VALUES)))
+
+        result = target.get_statement()
+
         self.assertEqual(
-            self.target.get_statement(),
+            result,
             "SELECT `pk`, `field_int`, `field_str`, `field_bool` "
             "FROM `FAKE_TABLE` WHERE `field_bool` = %s AND "
             "`field_int` = %s AND `field_str` = %s AND `pk` = %s")
+
+    def test_statement_EQ(self):
+        FAKE_EQ_VALUES = [filters.EQ(v) for v in FAKE_VALUES]
+        target = mysql.MySQLSelect(self._TABLE, dict(zip(
+            self._TABLE.get_column_names(), FAKE_EQ_VALUES)))
+
+        result = target.get_statement()
+
+        self.assertEqual(
+            result,
+            "SELECT `pk`, `field_int`, `field_str`, `field_bool` "
+            "FROM `FAKE_TABLE` WHERE `field_bool` = %s AND "
+            "`field_int` = %s AND `field_str` = %s AND `pk` = %s")
+
+    def test_statement_NE(self):
+        FAKE_NE_VALUES = [filters.NE(v) for v in FAKE_VALUES]
+        target = mysql.MySQLSelect(self._TABLE, dict(zip(
+            self._TABLE.get_column_names(), FAKE_NE_VALUES)))
+
+        result = target.get_statement()
+
+        self.assertEqual(
+            result,
+            "SELECT `pk`, `field_int`, `field_str`, `field_bool` "
+            "FROM `FAKE_TABLE` WHERE `field_bool` <> %s AND "
+            "`field_int` <> %s AND `field_str` <> %s AND `pk` <> %s")
+
+    def test_statement_GT(self):
+        FAKE_GT_VALUES = [filters.GT(v) for v in FAKE_VALUES]
+        target = mysql.MySQLSelect(self._TABLE, dict(zip(
+            self._TABLE.get_column_names(), FAKE_GT_VALUES)))
+
+        result = target.get_statement()
+
+        self.assertEqual(
+            result,
+            "SELECT `pk`, `field_int`, `field_str`, `field_bool` "
+            "FROM `FAKE_TABLE` WHERE `field_bool` > %s AND "
+            "`field_int` > %s AND `field_str` > %s AND `pk` > %s")
+
+    def test_statement_GE(self):
+        FAKE_GE_VALUES = [filters.GE(v) for v in FAKE_VALUES]
+        target = mysql.MySQLSelect(self._TABLE, dict(zip(
+            self._TABLE.get_column_names(), FAKE_GE_VALUES)))
+
+        result = target.get_statement()
+
+        self.assertEqual(
+            result,
+            "SELECT `pk`, `field_int`, `field_str`, `field_bool` "
+            "FROM `FAKE_TABLE` WHERE `field_bool` >= %s AND "
+            "`field_int` >= %s AND `field_str` >= %s AND `pk` >= %s")
+
+    def test_statement_LT(self):
+        FAKE_LT_VALUES = [filters.LT(v) for v in FAKE_VALUES]
+        target = mysql.MySQLSelect(self._TABLE, dict(zip(
+            self._TABLE.get_column_names(), FAKE_LT_VALUES)))
+
+        result = target.get_statement()
+
+        self.assertEqual(
+            result,
+            "SELECT `pk`, `field_int`, `field_str`, `field_bool` "
+            "FROM `FAKE_TABLE` WHERE `field_bool` < %s AND "
+            "`field_int` < %s AND `field_str` < %s AND `pk` < %s")
+
+    def test_statement_LE(self):
+        FAKE_LE_VALUES = [filters.LE(v) for v in FAKE_VALUES]
+        target = mysql.MySQLSelect(self._TABLE, dict(zip(
+            self._TABLE.get_column_names(), FAKE_LE_VALUES)))
+
+        result = target.get_statement()
+
+        self.assertEqual(
+            result,
+            "SELECT `pk`, `field_int`, `field_str`, `field_bool` "
+            "FROM `FAKE_TABLE` WHERE `field_bool` <= %s AND "
+            "`field_int` <= %s AND `field_str` <= %s AND `pk` <= %s")

--- a/restalchemy/tests/unit/storage/sql/test_filters.py
+++ b/restalchemy/tests/unit/storage/sql/test_filters.py
@@ -1,0 +1,114 @@
+# vim: tabstop=4 shiftwidth=4 softtabstop=4
+#
+# Copyright 2018 Eugene Frolov <eugene@frolov.net.ru>
+#
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from restalchemy.storage.sql import filters
+from restalchemy.tests.unit import base
+
+
+TEST_NAME = 'FAKE_NAME'
+TEST_VALUE = 'FAKE_VALUE'
+
+
+class EQTestCase(base.BaseTestCase):
+
+    def setUp(self):
+        self._expr = filters.EQ(value=TEST_VALUE)
+
+    def test_construct_expression(self):
+
+        result = self._expr.construct_expression(name=TEST_NAME)
+
+        self.assertEqual(result, '`' + TEST_NAME + '` = %s')
+
+    def test_value_property(self):
+        self.assertEqual(self._expr.value, TEST_VALUE)
+
+
+class NETestCase(base.BaseTestCase):
+
+    def setUp(self):
+        self._expr = filters.NE(value=TEST_VALUE)
+
+    def test_construct_expression(self):
+
+        result = self._expr.construct_expression(name=TEST_NAME)
+
+        self.assertEqual(result, '`' + TEST_NAME + '` <> %s')
+
+    def test_value_property(self):
+        self.assertEqual(self._expr.value, TEST_VALUE)
+
+
+class GTTestCase(base.BaseTestCase):
+
+    def setUp(self):
+        self._expr = filters.GT(value=TEST_VALUE)
+
+    def test_construct_expression(self):
+
+        result = self._expr.construct_expression(name=TEST_NAME)
+
+        self.assertEqual(result, '`' + TEST_NAME + '` > %s')
+
+    def test_value_property(self):
+        self.assertEqual(self._expr.value, TEST_VALUE)
+
+
+class GETestCase(base.BaseTestCase):
+
+    def setUp(self):
+        self._expr = filters.GE(value=TEST_VALUE)
+
+    def test_construct_expression(self):
+
+        result = self._expr.construct_expression(name=TEST_NAME)
+
+        self.assertEqual(result, '`' + TEST_NAME + '` >= %s')
+
+    def test_value_property(self):
+        self.assertEqual(self._expr.value, TEST_VALUE)
+
+
+class LTTestCase(base.BaseTestCase):
+
+    def setUp(self):
+        self._expr = filters.LT(value=TEST_VALUE)
+
+    def test_construct_expression(self):
+
+        result = self._expr.construct_expression(name=TEST_NAME)
+
+        self.assertEqual(result, '`' + TEST_NAME + '` < %s')
+
+    def test_value_property(self):
+        self.assertEqual(self._expr.value, TEST_VALUE)
+
+
+class LETestCase(base.BaseTestCase):
+
+    def setUp(self):
+        self._expr = filters.LE(value=TEST_VALUE)
+
+    def test_construct_expression(self):
+
+        result = self._expr.construct_expression(name=TEST_NAME)
+
+        self.assertEqual(result, '`' + TEST_NAME + '` <= %s')
+
+    def test_value_property(self):
+        self.assertEqual(self._expr.value, TEST_VALUE)


### PR DESCRIPTION
Example:

from restalchemy.storage.sql import filters

Model.objects.get_one(filters={'name': filters.EQ('value')})

Added classes:
  * AbstractExpression - abstract and base class for any expressions
  * EQ - is equal to
  * NE - is not equal to
  * GT - is greater than
  * GE - is greater than or equal to
  * LT - is less than
  * LE - is less than or equal to