### PR TITLE
Doesn't construct location header if a resource can't got from API

### DIFF
--- a/restalchemy/api/controllers.py
+++ b/restalchemy/api/controllers.py
@@ -16,11 +16,16 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import logging
+
 import webob
 
 from restalchemy.api import packers
 from restalchemy.api import resources
 from restalchemy.common import exceptions as exc
+
+
+LOG = logging.getLogger(__name__)
 
 
 class Controller(object):
@@ -43,8 +48,11 @@ class Controller(object):
                 try:
                     headers['Location'] = resources.ResourceMap.get_location(
                         body)
-                except ValueError:
-                    headers['Location'] = 'unknown'
+                except (exc.UnknownResourceLocation,
+                        exc.CanNotFindResourceByModel) as e:
+                    LOG.warning(
+                        "Can't construct location header by reason: %r",
+                        e)
             headers.update(h)
             return body, c, headers
 

--- a/restalchemy/api/resources.py
+++ b/restalchemy/api/resources.py
@@ -37,6 +37,8 @@ class ResourceMap(object):
     @classmethod
     def get_location(cls, model):
         resource = cls.get_resource_by_model(model)
+        if resource not in cls.resource_map:
+            raise exc.UnknownResourceLocation(resource=resource)
         return cls.resource_map[resource].get_uri(model)
 
     @classmethod
@@ -69,7 +71,7 @@ class ResourceMap(object):
         try:
             return self.model_to_resource[model_class]
         except KeyError:
-            raise ValueError("Can't find resource by model (%s)" % model)
+            raise exc.CanNotFindResourceByModel(model=model)
 
 
 @six.add_metaclass(abc.ABCMeta)

--- a/restalchemy/common/exceptions.py
+++ b/restalchemy/common/exceptions.py
@@ -68,6 +68,15 @@ class LocatorNotFound(NotFoundError):
                "Thus resource could not be found. ")
 
 
+class UnknownResourceLocation(NotFoundError):
+    message = ("Can not construct resource location for resource %(resource)r "
+               "because the resource can't be got using REST API")
+
+
+class CanNotFindResourceByModel(NotFoundError):
+    message = "Can not find a resource by model (%(model)r)"
+
+
 class IncorrectRouteAttributeClass(NotFoundError):
     message = "Route %(route)s is of unacceptable class"
 


### PR DESCRIPTION
A location will not added to HTTP headers in:
 - Resource controller doesn't have `get` method;
 - Resource controller returns unknown model from `create` method.